### PR TITLE
Change visibility of list of RowWrappers

### DIFF
--- a/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
+++ b/library/src/main/java/io/realm/RealmBasedRecyclerViewAdapter.java
@@ -87,7 +87,7 @@ public abstract class RealmBasedRecyclerViewAdapter
     protected RealmResults<T> realmResults;
     protected List ids;
 
-    private List<RowWrapper> rowWrappers;
+    protected List<RowWrapper> rowWrappers;
 
     private RealmChangeListener<RealmResults<T>> listener;
     private boolean animateResults;


### PR DESCRIPTION
Extended visibility allows for proper overriding of onBindHeaderViewHolder to allow for custom headers.